### PR TITLE
fix width of config form

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 ### 1.0.0-beta.3 (TBA)
 - Enh: People and spaces page
+- Enh: Fix width of configuration form
 
 ### 1.0.0-beta.2 (4/16/2023)
 - Enh: Space configurations

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -10,25 +10,24 @@ use humhub\libs\Html;
 /* @var $this \humhub\modules\ui\view\components\View */
 ?>
 
-<div class="container">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <?= \Yii::t('VerifiedModule.base', '<strong>Verified</strong> module configuration') ?></div>
-        <div class="panel-body">
-            <?php $form = ActiveForm::begin(['id' => 'configure-form']); ?>
-            <div class="form-group">
-                <?= $form->field($model, 'verifyUser')->widget(UserPickerField::class, ['id' => 'user_id', 'maxSelection' => \Yii::$app->getModule('verified')->getMaxNumber(), 'disabledItems' => [\Yii::$app->user->guid], 'placeholder' => \Yii::t('VerifiedModule.base', 'Add a member to verify')]); ?>
-                <?= $form->field($model, 'verifySpace')->widget(SpacePickerField::class, ['id' => 'space_id', 'placeholder' => \Yii::t('VerifiedModule.base', 'Add a space to be verified.')]); ?>
-                <?= $form->field($model, 'icon')->widget(IconPicker::class, ['options' => ['placeholder' => \Yii::t('VerifiedModule.base', 'Select icon ...')]]); ?>
-                <?= $form->field($model, 'color')->widget(ColorInput::class, ['options' => ['placeholder' => \Yii::t('VerifiedModule.base', 'Select color ...')]]); ?>
-                <?= $form->field($model, 'maxNumber'); ?>
-            </div>
-
-            <div class="form-group">
-                <?= Html::submitButton(\Yii::t('VerifiedModule.base', 'Save'), ['class' => 'btn btn-primary', 'data-ui-loader' => '']); ?>
-            </div>
-            
-            <?php ActiveForm::end(); ?>
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <?= \Yii::t('VerifiedModule.base', '<strong>Verified</strong> module configuration') ?>
+    </div>
+    <div class="panel-body">
+        <?php $form = ActiveForm::begin(['id' => 'configure-form']); ?>
+        <div class="form-group">
+            <?= $form->field($model, 'verifyUser')->widget(UserPickerField::class, ['id' => 'user_id', 'maxSelection' => \Yii::$app->getModule('verified')->getMaxNumber(), 'disabledItems' => [\Yii::$app->user->guid], 'placeholder' => \Yii::t('VerifiedModule.base', 'Add a member to verify')]); ?>
+            <?= $form->field($model, 'verifySpace')->widget(SpacePickerField::class, ['id' => 'space_id', 'placeholder' => \Yii::t('VerifiedModule.base', 'Add a space to be verified.')]); ?>
+            <?= $form->field($model, 'icon')->widget(IconPicker::class, ['options' => ['placeholder' => \Yii::t('VerifiedModule.base', 'Select icon ...')]]); ?>
+            <?= $form->field($model, 'color')->widget(ColorInput::class, ['options' => ['placeholder' => \Yii::t('VerifiedModule.base', 'Select color ...')]]); ?>
+            <?= $form->field($model, 'maxNumber'); ?>
         </div>
+
+        <div class="form-group">
+            <?= Html::submitButton(\Yii::t('VerifiedModule.base', 'Save'), ['class' => 'btn btn-primary', 'data-ui-loader' => '']); ?>
+        </div>
+        
+        <?php ActiveForm::end(); ?>
     </div>
 </div>


### PR DESCRIPTION
The form was overlapping the screen (at least on my laptop).
I have removed the `<div class="container">`.
It's already present in the page (but wrapping the left menu and the form) and CSS adds a fix width to it.

The diff shows a lot of changes just because the indentation changed.