### PR TITLE
Use primary color as default

### DIFF
--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -126,7 +126,7 @@ class ConfigureForm extends ActiveRecord
         $this->maxNumber = $settings->get('maxNumber');
         $this->verifyUser = (array)$settings->getSerialized('verifyUser');
         $this->verifySpace = (array)$settings->getSerialized('verifySpace');
-        $this->color = $settings->get('color', Yii::$app->getView()->theme->variable('default'));
+        $this->color = $settings->get('color', Yii::$app->getView()->theme->variable('primary'));
 
         return true;
     }


### PR DESCRIPTION
The "default" color (community theme: #f3f3f3) is barely visible with a white background (e.g. posts, people and spaces page).